### PR TITLE
Add and use currency constants instead of strings

### DIFF
--- a/LiqPay.php
+++ b/LiqPay.php
@@ -28,10 +28,21 @@
  */
 class LiqPay
 {
+    const CURRENCY_EUR = 'EUR';
+    const CURRENCY_USD = 'USD';
+    const CURRENCY_UAH = 'UAH';
+    const CURRENCY_RUB = 'RUB';
+    const CURRENCY_RUR = 'RUR';
 
     private $_api_url = 'https://www.liqpay.com/api/';
     private $_checkout_url = 'https://www.liqpay.com/api/3/checkout';
-    protected $_supportedCurrencies = array('EUR','UAH','USD','RUB','RUR');
+    protected $_supportedCurrencies = array(
+        self::CURRENCY_EUR,
+        self::CURRENCY_USD,
+        self::CURRENCY_UAH,
+        self::CURRENCY_RUB,
+        self::CURRENCY_RUR,
+    );
     private $_public_key;
     private $_private_key;
 
@@ -180,8 +191,8 @@ class LiqPay
         if (!in_array($params['currency'], $this->_supportedCurrencies)) {
             throw new InvalidArgumentException('currency is not supported');
         }
-        if ($params['currency'] == 'RUR') {
-            $params['currency'] = 'RUB';
+        if ($params['currency'] == self::CURRENCY_RUR) {
+            $params['currency'] = self::CURRENCY_RUB;
         }
         if (!isset($params['description'])) {
             throw new InvalidArgumentException('description is null');


### PR DESCRIPTION
With this changes it'll be more clearer to pass a correct currency value to your API methods like:

```php
$liqpay = new LiqPay($public_key, $private_key);
$html = $liqpay->cnb_form(array(
    'currency' => LiqPay::CURRENCY_USD,
    // other params...
));
```

Also, I think it will reduce possible bugs.