### PR TITLE
add getSignature and validateData methods

### DIFF
--- a/LiqPay.php
+++ b/LiqPay.php
@@ -89,11 +89,11 @@ class LiqPay
             throw new InvalidArgumentException('version is null');
         }
         $params['public_key'] = $this->_public_key;
+        $data = $this->encode_params($params);
         $postfields  = http_build_query(array(
-            'data'  => $this->encode_params($params),
+            'data'  => $data,
             'signature' => $this->getSignature($data)
         ));
-
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $this->_api_url . $path);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); // Avoid MITM vulnerability http://phpsecurity.readthedocs.io/en/latest/Input-Validation.html#validation-of-input-sources

--- a/LiqPay.php
+++ b/LiqPay.php
@@ -88,18 +88,14 @@ class LiqPay
         if (!isset($params['version'])) {
             throw new InvalidArgumentException('version is null');
         }
-        $url         = $this->_api_url . $path;
-        $public_key  = $this->_public_key;
-        $private_key = $this->_private_key;
-        $data        = $this->encode_params(array_merge(compact('public_key'), $params));
-        $signature   = $this->getSignature($data);
+        $params['public_key'] = $this->_public_key;
         $postfields  = http_build_query(array(
-            'data'  => $data,
-            'signature' => $signature
+            'data'  => $this->encode_params($params),
+            'signature' => $this->getSignature($data)
         ));
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_URL, $this->_api_url . $path);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true); // Avoid MITM vulnerability http://phpsecurity.readthedocs.io/en/latest/Input-Validation.html#validation-of-input-sources
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);    // Check the existence of a common name and also verify that it matches the hostname provided
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT ,$timeout);   // The number of seconds to wait while trying to connect


### PR DESCRIPTION
`getSignature` is better than `str_to_sign` or `cnb_signature` because suitable for validate callback from LiqPay (manipulating by private key only inside class). `str_to_sign` and` cnb_signature` remain for backward compatibility.
`validateData` validate callback from LiqPay