### PR TITLE
Add redirect url generator

### DIFF
--- a/LiqPay.php
+++ b/LiqPay.php
@@ -156,6 +156,26 @@ class LiqPay
             $language
         );
     }
+  
+    /**
+     * cnb_redirect_url
+     *
+     * @param array $params
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    public function cnb_redirect_url($params) {
+        $params = $this->cnb_params($params);
+        $data = $this->encode_params($params);
+        $signature = $this->cnb_signature($params);
+        
+        return $this->_checkout_url . "?" . http_build_query([
+            'data' => $data,
+            'signature' => $signature,
+        ]);
+    }
     
     /**
      * cnb_form raw data for custom form


### PR DESCRIPTION
Add redirect url in addition to form generator, so user can be just redirected by server.

Before, i used to do in next way:
```
echo $liqpay->cnb_form(...);
echo "<script>document.querySelector('#liqpay_form').submit()</script>";
```

Now I can just redirect user to payment page.