### PR TITLE
Move dependency 'phpunit/phpunit' to the 'require-dev' block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         }
     ],
     "require":{
-        "php":">=5.3.0",
+        "php":">=5.3.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": ">=10.3.1"
     },
     "autoload":{


### PR DESCRIPTION
Move 'phpunit/phpunit' dependency to the 'require-dev' section since it's only needed for development, testing, and building. Placing it in 'require' suggests it's essential for production, which it isn't. This separation simplifies dependency management and avoids potential conflicts.